### PR TITLE
neuca changes to fetch data from comet when configured

### DIFF
--- a/neuca-py/neuca_guest_tools/comet_common_iface.py
+++ b/neuca-py/neuca_guest_tools/comet_common_iface.py
@@ -34,11 +34,11 @@ class CometInterface:
         return headers
 
     @classmethod
-    def get_family(self, sliceId, unitId, readToken, family):
+    def get_family(self, sliceId, rId, readToken, family):
         params = {
             'contextID':sliceId,
             'family':family,
-            'Key':unitId,
+            'Key':rId,
             'readToken':readToken
         }
         if self._verify == False:
@@ -53,11 +53,11 @@ class CometInterface:
         return response
 
     @classmethod
-    def update_family(self, sliceId, unitId, readToken, writeToken, family, value):
+    def update_family(self, sliceId, rId, readToken, writeToken, family, value):
         params = {
             'contextID':sliceId,
             'family':family,
-            'Key':unitId,
+            'Key':rId,
             'readToken':readToken,
             'writeToken':writeToken
         }
@@ -72,11 +72,11 @@ class CometInterface:
         return response
 
     @classmethod
-    def delete_family(self, sliceId, unitId, readToken, writeToken, family):
+    def delete_family(self, sliceId, rId, readToken, writeToken, family):
         params = {
             'contextID':sliceId,
             'family':family,
-            'Key':unitId,
+            'Key':rId,
             'readToken':readToken,
             'writeToken':writeToken
         }
@@ -109,15 +109,15 @@ class CometInterface:
         return response
 
     @classmethod
-    def delete_families(self, sliceId, unitId, readToken, writeToken):
+    def delete_families(self, sliceId, rId, readToken, writeToken):
         retVal=True
         response = self.enumerate_families(sliceId, readToken)
         if response.status_code != 200:
             raise CometException('delete_families: Cannot Enumerate Scope: ' + str(response.status_code))
         if response.json()["value"] and response.json()["value"]["entries"]:
             for key in response.json()["value"]["entries"]:
-                LOG.debug ("delete_families: Deleting Family: '" + key["family"] + "' SliceId: '" + sliceId + "' unitId: '" + unitId + "'")
-                response = self.delete_family(sliceId, unitId, readToken, writeToken, key["family"])
+                LOG.debug ("delete_families: Deleting Family: '" + key["family"] + "' SliceId: '" + sliceId + "' rId: '" + rId + "'")
+                response = self.delete_family(sliceId, rId, readToken, writeToken, key["family"])
                 if response.status_code != 200:
                     LOG.debug('delete_families: Cannot Delete Family: ' + key["family"])
                     retVal|=False

--- a/neuca-py/neuca_guest_tools/comet_common_iface.py
+++ b/neuca-py/neuca_guest_tools/comet_common_iface.py
@@ -3,10 +3,12 @@
 import logging as LOG
 import requests
 import urllib3
+import string
+from random import shuffle
+
 
 urllib3.disable_warnings()
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-
 
 class CometException(Exception):
     pass
@@ -14,17 +16,13 @@ class CometException(Exception):
 class CometInterface:
     @classmethod
     def __init__(self, cometHost, caCert, clientCert, clientKey):
-        self._cometHost = cometHost
+        self._cometHost = cometHost.split(",")
         if caCert != None:
             self._verify = caCert
             self._cert = (clientCert, clientKey)
         else :
             self._verify = False
             self._cert = None
-
-    @classmethod
-    def _url(self, path):
-        return self._cometHost + path
 
     @classmethod
     def _headers(self):
@@ -34,7 +32,26 @@ class CometInterface:
         return headers
 
     @classmethod
-    def get_family(self, sliceId, rId, readToken, family):
+    def invokeRoundRobinApi(self, operation, sliceId, rId, readToken, writeToken, family, value):
+        response = None
+        shuffle(self._cometHost)
+        for host in self._cometHost:
+            if operation == 'get_family' :
+                response = self.get_family(host, sliceId, rId, readToken, family)
+            elif operation == 'update_family' :
+                response = self.update_family(host, sliceId, rId, readToken, writeToken, family, value)
+            elif operation == 'delete_family' :
+                response = self.delete_family(host, sliceId, rId, readToken, writeToken, family)
+            elif operation == 'enumerate_families' :
+                response = self.enumerate_families(host, sliceId, readToken)
+            elif operation == 'delete_families' :
+                response = delete_families(host, sliceId, rId, readToken, writeToken)
+            if response.status_code == 200:
+                break
+        return response
+
+    @classmethod
+    def get_family(self, host, sliceId, rId, readToken, family):
         params = {
             'contextID':sliceId,
             'family':family,
@@ -42,10 +59,9 @@ class CometInterface:
             'readToken':readToken
         }
         if self._verify == False:
-            response = requests.get(self._url('/readScope'), headers=self._headers(), params=params, verify=False)
+            response = requests.get((host + '/readScope'), headers=self._headers(), params=params, verify=False)
         else:
-            #response = requests.get(self._url('/readScope'), headers=self._headers(), params=params, cert= self._cert, verify=self._verify)
-            response = requests.get(self._url('/readScope'), headers=self._headers(), params=params, cert= self._cert, verify=False)
+            response = requests.get((host + '/readScope'), headers=self._headers(), params=params, cert= self._cert, verify=False)
         LOG.debug ("get_family: Received Response Status Code: " + str(response.status_code))
         LOG.debug ("get_family: Received Response Message: " + response.json()["message"])
         LOG.debug ("get_family: Received Response Status: " + response.json()["status"])
@@ -53,7 +69,7 @@ class CometInterface:
         return response
 
     @classmethod
-    def update_family(self, sliceId, rId, readToken, writeToken, family, value):
+    def update_family(self, host, sliceId, rId, readToken, writeToken, family, value):
         params = {
             'contextID':sliceId,
             'family':family,
@@ -62,9 +78,9 @@ class CometInterface:
             'writeToken':writeToken
         }
         if self._verify == False:
-            response = requests.post(self._url('/writeScope'), headers=self._headers(), params=params, verify=False, json=value)
+            response = requests.post((host +'/writeScope'), headers=self._headers(), params=params, verify=False, json=value)
         else:
-            response = requests.post(self._url('/writeScope'), headers=self._headers(), params=params, cert= self._cert, verify=self._verify, json=value)
+            response = requests.post((host +'/writeScope'), headers=self._headers(), params=params, cert= self._cert, verify=self._verify, json=value)
         LOG.debug ("update_family: Received Response Status Code: " + str(response.status_code))
         LOG.debug ("update_family: Received Response Message: " + response.json()["message"])
         LOG.debug ("update_family: Received Response Status: " + response.json()["status"])
@@ -72,7 +88,7 @@ class CometInterface:
         return response
 
     @classmethod
-    def delete_family(self, sliceId, rId, readToken, writeToken, family):
+    def delete_family(self, host, sliceId, rId, readToken, writeToken, family):
         params = {
             'contextID':sliceId,
             'family':family,
@@ -81,10 +97,9 @@ class CometInterface:
             'writeToken':writeToken
         }
         if self._verify == False:
-            response = requests.delete(self._url('/deleteScope'), headers=self._headers(), params=params, verify=False)
+            response = requests.delete((host +'/deleteScope'), headers=self._headers(), params=params, verify=False)
         else:
-            #response = requests.delete(self._url('/deleteScope'), headers=self._headers(), params=params, cert= self._cert, verify=self._verify)
-            response = requests.delete(self._url('/deleteScope'), headers=self._headers(), params=params, cert= self._cert, verify=False)
+            response = requests.delete((host +'/deleteScope'), headers=self._headers(), params=params, cert= self._cert, verify=False)
         LOG.debug ("delete_family: Received Response Status Code: " + str(response.status_code))
         LOG.debug ("delete_family: Received Response Message: " + response.json()["message"])
         LOG.debug ("delete_family: Received Response Status: " + response.json()["status"])
@@ -92,16 +107,15 @@ class CometInterface:
         return response
 
     @classmethod
-    def enumerate_families(self, sliceId, readToken):
+    def enumerate_families(self, host, sliceId, readToken):
         params = {
             'contextID':sliceId,
             'readToken':readToken,
         }
         if self._verify == False:
-            response = requests.get(self._url('/enumerateScope'), headers=self._headers(), params=params, verify=False)
+            response = requests.get((host +'/enumerateScope'), headers=self._headers(), params=params, verify=False)
         else:
-            #response = requests.get(self._url('/enumerateScope'), headers=self._headers(), params=params, cert= self._cert, verify=self._verify)
-            response = requests.get(self._url('/enumerateScope'), headers=self._headers(), params=params, cert= self._cert, verify=False)
+            response = requests.get((host +'/enumerateScope'), headers=self._headers(), params=params, cert= self._cert, verify=False)
         LOG.debug ("enumerate_families: Received Response Status Code: " + str(response.status_code))
         LOG.debug ("enumerate_families: Received Response Message: " + response.json()["message"])
         LOG.debug ("enumerate_families: Received Response Status: " + response.json()["status"])
@@ -109,7 +123,7 @@ class CometInterface:
         return response
 
     @classmethod
-    def delete_families(self, sliceId, rId, readToken, writeToken):
+    def delete_families(self, host, sliceId, rId, readToken, writeToken):
         retVal=True
         response = self.enumerate_families(sliceId, readToken)
         if response.status_code != 200:

--- a/neuca-py/neuca_guest_tools/comet_common_iface.py
+++ b/neuca-py/neuca_guest_tools/comet_common_iface.py
@@ -1,0 +1,124 @@
+# comet_common_iface.py
+
+import logging as LOG
+import requests
+import urllib3
+
+urllib3.disable_warnings()
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+class CometException(Exception):
+    pass
+
+class CometInterface:
+    @classmethod
+    def __init__(self, cometHost, caCert, clientCert, clientKey):
+        self._cometHost = cometHost
+        if caCert != None:
+            self._verify = caCert
+            self._cert = (clientCert, clientKey)
+        else :
+            self._verify = False
+            self._cert = None
+
+    @classmethod
+    def _url(self, path):
+        return self._cometHost + path
+
+    @classmethod
+    def _headers(self):
+        headers = {
+            'Accept': 'application/json',
+        }
+        return headers
+
+    @classmethod
+    def get_family(self, sliceId, unitId, readToken, family):
+        params = {
+            'contextID':sliceId,
+            'family':family,
+            'Key':unitId,
+            'readToken':readToken
+        }
+        if self._verify == False:
+            response = requests.get(self._url('/readScope'), headers=self._headers(), params=params, verify=False)
+        else:
+            #response = requests.get(self._url('/readScope'), headers=self._headers(), params=params, cert= self._cert, verify=self._verify)
+            response = requests.get(self._url('/readScope'), headers=self._headers(), params=params, cert= self._cert, verify=False)
+        LOG.debug ("get_family: Received Response Status Code: " + str(response.status_code))
+        LOG.debug ("get_family: Received Response Message: " + response.json()["message"])
+        LOG.debug ("get_family: Received Response Status: " + response.json()["status"])
+        LOG.debug ("get_family: Received Response Value: " + str(response.json()["value"]))
+        return response
+
+    @classmethod
+    def update_family(self, sliceId, unitId, readToken, writeToken, family, value):
+        params = {
+            'contextID':sliceId,
+            'family':family,
+            'Key':unitId,
+            'readToken':readToken,
+            'writeToken':writeToken
+        }
+        if self._verify == False:
+            response = requests.post(self._url('/writeScope'), headers=self._headers(), params=params, verify=False, json=value)
+        else:
+            response = requests.post(self._url('/writeScope'), headers=self._headers(), params=params, cert= self._cert, verify=self._verify, json=value)
+        LOG.debug ("update_family: Received Response Status Code: " + str(response.status_code))
+        LOG.debug ("update_family: Received Response Message: " + response.json()["message"])
+        LOG.debug ("update_family: Received Response Status: " + response.json()["status"])
+        LOG.debug ("update_family: Received Response Value: " + str(response.json()["value"]))
+        return response
+
+    @classmethod
+    def delete_family(self, sliceId, unitId, readToken, writeToken, family):
+        params = {
+            'contextID':sliceId,
+            'family':family,
+            'Key':unitId,
+            'readToken':readToken,
+            'writeToken':writeToken
+        }
+        if self._verify == False:
+            response = requests.delete(self._url('/deleteScope'), headers=self._headers(), params=params, verify=False)
+        else:
+            #response = requests.delete(self._url('/deleteScope'), headers=self._headers(), params=params, cert= self._cert, verify=self._verify)
+            response = requests.delete(self._url('/deleteScope'), headers=self._headers(), params=params, cert= self._cert, verify=False)
+        LOG.debug ("delete_family: Received Response Status Code: " + str(response.status_code))
+        LOG.debug ("delete_family: Received Response Message: " + response.json()["message"])
+        LOG.debug ("delete_family: Received Response Status: " + response.json()["status"])
+        LOG.debug ("delete_family: Received Response Value: " + str(response.json()["value"]))
+        return response
+
+    @classmethod
+    def enumerate_families(self, sliceId, readToken):
+        params = {
+            'contextID':sliceId,
+            'readToken':readToken,
+        }
+        if self._verify == False:
+            response = requests.get(self._url('/enumerateScope'), headers=self._headers(), params=params, verify=False)
+        else:
+            #response = requests.get(self._url('/enumerateScope'), headers=self._headers(), params=params, cert= self._cert, verify=self._verify)
+            response = requests.get(self._url('/enumerateScope'), headers=self._headers(), params=params, cert= self._cert, verify=False)
+        LOG.debug ("enumerate_families: Received Response Status Code: " + str(response.status_code))
+        LOG.debug ("enumerate_families: Received Response Message: " + response.json()["message"])
+        LOG.debug ("enumerate_families: Received Response Status: " + response.json()["status"])
+        LOG.debug ("enumerate_families: Received Response Value: " + str(response.json()["value"]))
+        return response
+
+    @classmethod
+    def delete_families(self, sliceId, unitId, readToken, writeToken):
+        retVal=True
+        response = self.enumerate_families(sliceId, readToken)
+        if response.status_code != 200:
+            raise CometException('delete_families: Cannot Enumerate Scope: ' + str(response.status_code))
+        if response.json()["value"] and response.json()["value"]["entries"]:
+            for key in response.json()["value"]["entries"]:
+                LOG.debug ("delete_families: Deleting Family: '" + key["family"] + "' SliceId: '" + sliceId + "' unitId: '" + unitId + "'")
+                response = self.delete_family(sliceId, unitId, readToken, writeToken, key["family"])
+                if response.status_code != 200:
+                    LOG.debug('delete_families: Cannot Delete Family: ' + key["family"])
+                    retVal|=False
+        return retVal

--- a/neuca-py/neuca_guest_tools/customizer.py
+++ b/neuca-py/neuca_guest_tools/customizer.py
@@ -1312,7 +1312,7 @@ class NEucaLinuxCustomizer(NEucaOSCustomizer):
             updateIface = False
             if sysName:
                 del systemIfaces[mac]
-                updateIface = self.__updateUdevFile(mac, sysName, config,
+                updateIface = self.__updateUdevFile(mac, sysName, iface[1],
                                                     self.udevDataPrio)
 
             if updateIface or self.firstRun:
@@ -1353,11 +1353,15 @@ class NEucaLinuxCustomizer(NEucaOSCustomizer):
         # update routes
         self.__updateRouter(self.isRouter())
         routes = self.getAllRoutes()
+        if routes is None:
+            return
         for route in routes:
             self.__updateRoute(route[0], route[1])
 
     def runNewScripts(self):
         scripts = self.instanceData.getAllScripts()
+        if scripts is None:
+            return
         for s in scripts:
             script = NeucaScript(s[0], s[1])
             script.run()
@@ -1374,6 +1378,8 @@ class NEucaLinuxCustomizer(NEucaOSCustomizer):
         self.__updateISCSI_initiator(iscsi_iqn)
 
         storage_list = self.instanceData.getAllStorage()
+        if storage_list is None:
+            return
         for device in storage_list:
             dev_name = device[0]
             dev_fields = dict(enumerate(device[1].split(':')))

--- a/neuca-py/neuca_guest_tools/customizer.py
+++ b/neuca-py/neuca_guest_tools/customizer.py
@@ -24,7 +24,6 @@ import socket
 import subprocess
 import time
 import glob
-import json
 
 from neuca_guest_tools import CONFIG, LOGGER
 from neuca_guest_tools import _IPV4_LOOPBACK_NET as loopbackNet

--- a/neuca-py/neuca_guest_tools/instancedata.py
+++ b/neuca-py/neuca_guest_tools/instancedata.py
@@ -40,7 +40,7 @@ class NEucaInstanceData(object):
         self.storage = None
         self.scripts = None
         self.routes = None
-        
+
         try:
             self.__testing__ = CONFIG.getboolean('runtime', 'testing')
         except Exception:
@@ -99,26 +99,26 @@ class NEucaInstanceData(object):
             result = []
             for s in storage :
                 device=str(s["device"])
-                config=str(s["storageType"]) 
-                config+=":" 
-                config+=str(s["targetIp"]) 
-                config+=":" 
-                config+=str(s["targetPort"]) 
-                config+=":" 
-                config+=str(s["targetLun"]) 
-                config+=":" 
-                config+=str(s["targetChapUser"]) 
-                config+=":" 
+                config=str(s["storageType"])
+                config+=":"
+                config+=str(s["targetIp"])
+                config+=":"
+                config+=str(s["targetPort"])
+                config+=":"
+                config+=str(s["targetLun"])
+                config+=":"
+                config+=str(s["targetChapUser"])
+                config+=":"
                 config+=str(s["targetChapSecret"])
-                config+=":" 
+                config+=":"
                 config+=str(s["targetShouldAttach"])
-                config+=":" 
+                config+=":"
                 config+=str(s["fsType"])
-                config+=":" 
-                config+=str(s["fsOptions"]) 
-                config+=":" 
-                config+=str(s["fsShouldFormat"]) 
-                config+=":" 
+                config+=":"
+                config+=str(s["fsOptions"])
+                config+=":"
+                config+=str(s["fsShouldFormat"])
+                config+=":"
                 config+=str(s["fsMountPoint"])
                 tup = device, config
                 result.append(tup)
@@ -226,7 +226,7 @@ class NEucaInstanceData(object):
 
     def getAllScripts(self):
         if self.getCometHost() is not None :
-            return self.scripts 
+            return self.scripts
         else :
             return self.config.items('scripts')
 
@@ -253,7 +253,7 @@ class NEucaInstanceData(object):
 
     def getAllRoutes(self):
         if self.getCometHost() is not None :
-            return self.storage 
+            return self.routes
         else :
             return self.config.items('routes')
 

--- a/neuca-py/neuca_guest_tools/instancedata.py
+++ b/neuca-py/neuca_guest_tools/instancedata.py
@@ -203,7 +203,7 @@ class NEucaInstanceData(object):
         readToken = self.getUserDataField("global", "cometreadtoken")
         if sliceId is not None and rId is not None and readToken is not None:
             comet = CometInterface(self.getCometHost(), None, None, None)
-            resp = comet.get_family(sliceId, rId, readToken, section)
+            resp = comet.invokeRoundRobinApi('get_family', sliceId, rId, readToken, None, section, None)
             if resp.status_code != 200:
                 print ("Failure occured in fetching family from comet" + section)
                 return None

--- a/neuca-py/neuca_guest_tools/instancedata.py
+++ b/neuca-py/neuca_guest_tools/instancedata.py
@@ -35,6 +35,12 @@ class NEucaInstanceData(object):
         self.publicIP = None
         self.userData = None
         self.fetchTime = 0
+        self.interfaces = None
+        self.users = None
+        self.storage = None
+        self.scripts = None
+        self.routes = None
+        
         try:
             self.__testing__ = CONFIG.getboolean('runtime', 'testing')
         except Exception:
@@ -45,6 +51,98 @@ class NEucaInstanceData(object):
         rtnStr = f.read()
         f.close()
         return rtnStr
+
+    def updateInterfacesFromComet(self):
+        interfaces=self.getCometData('interfaces')
+        if interfaces is not None:
+            result = []
+            for i in interfaces:
+                mac=str(i["mac"])
+                value=str(i["state"])
+                value+=":"
+                value+=str(i["ipVersion"])
+                value+=":"
+                if i.get("ip") :
+                    value+=str(i["ip"])
+                tup=mac,value
+                result.append(tup)
+            return result
+        return None
+
+    def updateScriptsFromComet(self):
+        scripts = self.getCometData('scripts')
+        if scripts is not None :
+            result = []
+            for s in scripts:
+                scriptName=str(s["scriptName"])
+                scriptBody=str(s["scriptBody"])
+                tup=scriptName,scriptBody
+                result.append(tup)
+            return result
+        return None
+
+    def updateRoutesFromComet(self):
+        routes = self.getCometData('routes')
+        if routes is not None :
+            result = []
+            for r in routes:
+                routeNetwork=str(r["routeNetwork"])
+                routeNextHop=str(r["routeNextHop"])
+                tup = routeNetwork, routeNextHop
+                result.append(tup)
+            return result
+        return None
+
+    def updateStorageFromComet(self):
+        storage = self.getCometData('storage')
+        if storage is not None:
+            result = []
+            for s in storage :
+                device=str(s["device"])
+                config=str(s["storageType"]) 
+                config+=":" 
+                config+=str(s["targetIp"]) 
+                config+=":" 
+                config+=str(s["targetPort"]) 
+                config+=":" 
+                config+=str(s["targetLun"]) 
+                config+=":" 
+                config+=str(s["targetChapUser"]) 
+                config+=":" 
+                config+=str(s["targetChapSecret"])
+                config+=":" 
+                config+=str(s["targetShouldAttach"])
+                config+=":" 
+                config+=str(s["fsType"])
+                config+=":" 
+                config+=str(s["fsOptions"]) 
+                config+=":" 
+                config+=str(s["fsShouldFormat"]) 
+                config+=":" 
+                config+=str(s["fsMountPoint"])
+                tup = device, config
+                result.append(tup)
+            return result
+        return None
+
+    def updateUsersFromComet(self):
+        users = self.getCometData('users')
+        if users is not None :
+            result = []
+            for u in users :
+                login=str(u["user"])
+                sudokeys=str(u["sudo"]) + ":" + str(u["key"])
+                tup = login, sudokeys
+                result.append(tup)
+            return result
+        return None
+
+    def updateCometData(self):
+        self.interfaces = self.updateInterfacesFromComet()
+        self.scripts = self.updateScriptsFromComet()
+        self.routes = self.updateRoutesFromComet()
+        self.users = self.updateUsersFromComet()
+        self.storage = self.updateStorageFromComet()
 
     def updateInstanceData(self):
         # Local assignments, in order to shorten things.
@@ -65,13 +163,16 @@ class NEucaInstanceData(object):
         self.config = ConfigParser.RawConfigParser()
         self.config.read(fh.path)
 
+        if self.getCometHost() is not None :
+            self.updateCometData()
+
         # Finally, record when this instanceData was fetched, so we
         # know how "fresh" it is.
         self.fetchTime = time.time()
 
     def getUserDataField(self, section, field):
         try:
-	    if section == 'global' or self.getCometHost() is None :
+            if section == 'global' or self.getCometHost() is None :
                 return self.config.get(section, field)
             else :
                 return self.getCometDataField(section, field)
@@ -79,54 +180,53 @@ class NEucaInstanceData(object):
             return None
 
     def getCometDataField(self, section, field):
-        secData = self.getCometData(section)
-        if secData is not None :
-            secJson = json.loads(secData)
-            for s in secJson :
-		for value in s.values() :
-		  if value == field :
-		     return json.dumps(s)
-	return None
+        secData = None
+        if section == 'interfaces' :
+            secData = self.interfaces
+        elif section == 'users' :
+            secData = self.users
+        elif section == 'scripts' :
+            secData = self.scripts
+        elif section == 'routes' :
+            secData = self.routes
+        elif section == 'storage' :
+            secData = self.storage
+        if secData is not None:
+            for s in secData:
+                if s[0] == field :
+                    return s[1]
+        return None
 
     def getCometData(self, section):
         sliceId = self.getUserDataField("global", "slice_id")
-        unitId = self.getUserDataField("global", "unit_id")
+        rId = self.getUserDataField("global", "reservation_id")
         readToken = self.getUserDataField("global", "cometreadtoken")
-        if sliceId is not None and unitId is not None and readToken is not None:
+        if sliceId is not None and rId is not None and readToken is not None:
             comet = CometInterface(self.getCometHost(), None, None, None)
-            resp = comet.get_family(sliceId, unitId, readToken, section)
+            resp = comet.get_family(sliceId, rId, readToken, section)
             if resp.status_code != 200:
                 print ("Failure occured in fetching family from comet" + section)
                 return None
             if resp.json()["value"].get("error") :
                 print ("Error occured in fetching family from comet" + section + resp.json()["value"]["error"])
-		return None
+                return None
             elif resp.json()["value"] :
                 value = resp.json()["value"]["value"]
                 if value is not None :
                     secData = json.loads(json.loads(value)["val_"])
-                    return json.dumps(secData)
+                    return secData
             else:
                 return None
         else :
-            print("sliceId/unitId/readToken could not be determined")
+            print("sliceId/rId/readToken could not be determined")
             return None
 
     def getBootScript(self):
-        if self.getCometHost() is not None :
-            scripts = self.getCometData('scripts')
-            if scripts is not None :
-                scriptsJson = json.loads(scripts)
-                for script in scriptsJson :
-                   if script["scriptName"] == "bootscript" :
-                       return json.dumps(script)
-            return None
-        else :
-            return self.getUserDataField('scripts', 'bootscript')
+        return self.getUserDataField('scripts', 'bootscript')
 
     def getAllScripts(self):
         if self.getCometHost() is not None :
-            return self.getCometData('scripts')
+            return self.scripts 
         else :
             return self.config.items('scripts')
 
@@ -134,26 +234,26 @@ class NEucaInstanceData(object):
         return self.getUserDataField('interfaces', iface)
 
     def getAllInterfaces(self):
-         if self.getCometHost() is not None :
-             return self.getCometData('interfaces')
-         else :
-             return self.config.items('interfaces')
+        if self.getCometHost() is not None :
+            return self.interfaces
+        else :
+            return self.config.items('interfaces')
 
     def getAllUsers(self):
         if self.getCometHost() is not None :
-            return self.getCometData('users')
+            return self.users
         else :
             return self.config.items('users')
 
     def getAllStorage(self):
         if self.getCometHost() is not None :
-            return self.getCometData('storage')
+            return self.storage
         else :
             return self.config.items('storage')
 
     def getAllRoutes(self):
         if self.getCometHost() is not None :
-            return self.getCometData('routes')
+            return self.storage 
         else :
             return self.config.items('routes')
 
@@ -184,4 +284,7 @@ class NEucaInstanceData(object):
         return iqn
 
     def getCometHost(self):
-        return self.config.get("global", "comethost")
+        try:
+            return self.config.get("global", "comethost")
+        except Exception:
+            return None

--- a/neuca-py/neuca_guest_tools/neuca.py
+++ b/neuca-py/neuca_guest_tools/neuca.py
@@ -24,7 +24,6 @@ import sys
 import os
 
 import time
-import json
 
 from neuca_guest_tools import CONFIG, LOGGER
 from neuca_guest_tools import __version__ as neuca_version

--- a/neuca-py/neuca_guest_tools/neuca.py
+++ b/neuca-py/neuca_guest_tools/neuca.py
@@ -24,6 +24,7 @@ import sys
 import os
 
 import time
+import json
 
 from neuca_guest_tools import CONFIG, LOGGER
 from neuca_guest_tools import __version__ as neuca_version
@@ -48,7 +49,7 @@ class NEucad():
         self.pidDir = CONFIG.get('runtime', 'pid-directory')
 
         self.stdin_path = '/dev/null'
-        self.stdout_path = '/dev/null'
+        self.stdout_path = '/root/comet'
         self.stderr_path = '/dev/null'
         self.pidfile_path = (self.pidDir +
                              '/' +
@@ -132,6 +133,12 @@ def main():
               'to execute any newly created user-specified post-boot scripts')
         print('\tneuca-user-data - to retrieve full user data')
         print('\tneuca-get - to retrieve specific items from user data')
+        print('\tneuca-storage - ' +
+              'to retrieve all storage devices configured')
+        print('\tneuca-users - ' +
+              'to retrieve all users configured')
+        print('\tneuca-interfaces - ' +
+              'to retrieve all network interfaces')
         print('\tneuca-routes - ' +
               'to show whether host has been specified ' +
               'as a router, and get all routes')
@@ -202,15 +209,44 @@ def main():
 
     if invokeName == 'neuca-all-user-scripts':
         userScripts = customizer.getAllScripts()
-        for script in userScripts:
-            print script
+        if userScripts is None:
+            print "Not found"
+	else :
+            scriptsJson = json.loads(userScripts)
+            for script in scriptsJson:
+                print json.dumps(script)
 
     if invokeName == 'neuca-user-data':
         print customizer.getUserData()
 
+    if invokeName == 'neuca-interfaces':
+	interfaces = customizer.getAllInterfaces()
+        if interfaces is None:
+            print "Not found"
+	else :
+            print interfaces
+
+    if invokeName == 'neuca-storage':
+	storages = customizer.getAllStorage()
+        if storages is None:
+            print "Not found"
+	else :
+            print storages
+
+    if invokeName == 'neuca-users':
+	users = customizer.getAllUsers()
+        if users is None:
+            print "Not found"
+	else :
+            print users
+
     if invokeName == 'neuca-routes':
         print 'Router: ' + str(customizer.isRouter())
-        print customizer.getAllRoutes()
+	routes = customizer.getAllRoutes()
+        if routes is None:
+            print "Not found"
+	else :
+            print routes
 
     if invokeName == 'neuca-get-public-ip':
         print customizer.getPublicIP()

--- a/neuca-py/neuca_guest_tools/neuca.py
+++ b/neuca-py/neuca_guest_tools/neuca.py
@@ -49,7 +49,7 @@ class NEucad():
         self.pidDir = CONFIG.get('runtime', 'pid-directory')
 
         self.stdin_path = '/dev/null'
-        self.stdout_path = '/root/comet'
+        self.stdout_path = '/dev/null'
         self.stderr_path = '/dev/null'
         self.pidfile_path = (self.pidDir +
                              '/' +
@@ -211,7 +211,7 @@ def main():
         userScripts = customizer.getAllScripts()
         if userScripts is None:
             print "Not found"
-	else :
+        else :
             for script in userScripts:
                 print script
 
@@ -219,32 +219,32 @@ def main():
         print customizer.getUserData()
 
     if invokeName == 'neuca-interfaces':
-	interfaces = customizer.getAllInterfaces()
+        interfaces = customizer.getAllInterfaces()
         if interfaces is None:
             print "Not found"
-	else :
+        else :
             print interfaces
 
     if invokeName == 'neuca-storage':
-	storages = customizer.getAllStorage()
+        storages = customizer.getAllStorage()
         if storages is None:
             print "Not found"
-	else :
+        else :
             print storages
 
     if invokeName == 'neuca-users':
-	users = customizer.getAllUsers()
+        users = customizer.getAllUsers()
         if users is None:
             print "Not found"
-	else :
+        else :
             print users
 
     if invokeName == 'neuca-routes':
         print 'Router: ' + str(customizer.isRouter())
-	routes = customizer.getAllRoutes()
+        routes = customizer.getAllRoutes()
         if routes is None:
             print "Not found"
-	else :
+        else :
             print routes
 
     if invokeName == 'neuca-get-public-ip':

--- a/neuca-py/neuca_guest_tools/neuca.py
+++ b/neuca-py/neuca_guest_tools/neuca.py
@@ -212,9 +212,8 @@ def main():
         if userScripts is None:
             print "Not found"
 	else :
-            scriptsJson = json.loads(userScripts)
-            for script in scriptsJson:
-                print json.dumps(script)
+            for script in userScripts:
+                print script
 
     if invokeName == 'neuca-user-data':
         print customizer.getUserData()

--- a/neuca-py/setup.py
+++ b/neuca-py/setup.py
@@ -14,7 +14,8 @@ wrapper_script = 'neuca'
 wrapper_aliases = ['neuca-netconf', 'neuca-user-script',
                    'neuca-all-user-scripts',
                    'neuca-run-scripts', 'neuca-user-data',
-                   'neuca-get', 'neuca-routes',
+                   'neuca-get', 'neuca-routes', 'neuca-users',
+                   'neuca-interfaces', 'neuca-storage',
                    'neuca-get-public-ip', 'neuca-distro',
                    'neuca-version', 'neucad']
 


### PR DESCRIPTION
Update the neuca guest tools to fetch meta data for an instance from comet when comethost is configured in global section of openstack meta data.

If comethost is not configured, the guest tools behave as before and fetch information from openstack.

This pull request changes for https://github.com/RENCI-NRIG/neuca-guest-tools/issues/3

Corresponding ORCA Changes are tracked by https://github.com/RENCI-NRIG/orca5/issues/212