### PR TITLE
changes to set the hostname by removing /

### DIFF
--- a/neuca-py/neuca_guest_tools/customizer.py
+++ b/neuca-py/neuca_guest_tools/customizer.py
@@ -1546,6 +1546,7 @@ class NEucaLinuxCustomizer(NEucaOSCustomizer):
         except:
             old_hostname = None
 
+        new_hostname = new_hostname.replace('/','-')
         self.log.debug('new_hostname = %s, old_hostname = %s'
                        % (str(new_hostname), str(old_hostname)))
         if new_hostname != old_hostname:

--- a/neuca-py/neuca_guest_tools/instancedata.py
+++ b/neuca-py/neuca_guest_tools/instancedata.py
@@ -245,6 +245,7 @@ class NEucaInstanceData(object):
 
                             self.log.debug("check if " + h["hostName"] + " exists")
                             newHostsEntry = h["ip"] + '\t' + h["hostName"] + '\n'
+                            newHostsEntry = newHostsEntry.replace('/','-')
                             newHosts.append(str(newHostsEntry))
 
                 if newHosts is not None:
@@ -436,7 +437,7 @@ class NEucaInstanceData(object):
                     for h in hosts :
                         self.log.debug("Processing host " + h["hostName"])
                         self.log.debug("h[ip]=" + h["ip"] + " ip=" + ip)
-                        if h["hostName"] == hostName and h["ip"] != ip :
+                        if h["hostName"].replace('/','-') == hostName and h["ip"] != ip :
                             h["ip"] = ip
                             checker = True
                     if checker :


### PR DESCRIPTION
Code changes to address https://github.com/RENCI-NRIG/neuca-guest-tools/issues/8

Neuca tools updated to replace / with - before setting hostname or any hostname comparison.
With this change hostname command can still be used and it is not required to use hostnamectl.

Change cannot be made on ORCA for following reasons:

In ORCA ModifyHandler::createNewNodeGroupNode function generates the host name and uses / as a separator. Since GUIDs also have hyphen '-', we cannot use '-' as a separator. Instead of changing hostname generation in ORCA, updating neuca guest tools to remove '/' before applying hostname.

Using - instead of / in ORCA results in following error:
```
2018-12-10 17:29:45,409 [pool-3-thread-1] ERROR controller.PublishManager - getSliceManifest(): converter unable to get manifest: com.hp.hpl.jena.shared.BadURIException: Only well-formed absolute URIrefs can be included in RDF/XML output: <http://geni-orca.renci.org/owl/2f6f0f8f-e69f-43f2-b979-fdcd7c09cf1c#Link7-NodeGroup0/02f6f0f8f-e69f-43f2-b979-fdcd7c09cf1c#NodeGroup0-NoIP-2e75e5e1-7e99-4301-a521-491e1fcbef05/intf> Code: 0/ILLEGAL_CHARACTER in FRAGMENT: The character violates the grammar rules for URIs/IRIs.
2018-12-10 17:29:45,410 [pool-3-thread-1] ERROR controller.PublishManager - getSliceManifest(): Exception encountered: OrcaControllerException: ERROR: Failed due to exception: com.hp.hpl.jena.shared.BadURIException: Only well-formed absolute URIrefs can be included in RDF/XML output: <http://geni-orca.renci.org/owl/2f6f0f8f-e69f-43f2-b979-fdcd7c09cf1c#Link7-NodeGroup0/02f6f0f8f-e69f-43f2-b979-fdcd7c09cf1c#NodeGroup0-NoIP-2e75e5e1-7e99-4301-a521-491e1fcbef05/intf> Code: 0/ILLEGAL_CHARACTER in FRAGMENT: The character violates the grammar rules for URIs/IRIs.
```